### PR TITLE
Upgrade backend to Python 3.12

### DIFF
--- a/Docker-Compose-Files/Docker-compose_windows.yml
+++ b/Docker-Compose-Files/Docker-compose_windows.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - yacht:/config
       - /var/run/docker.sock:/var/run/docker.sock
-    image: selfhostedpro/yacht
+    image: wickedyoda/yacht:main
 
 volumes:
   yacht:

--- a/Docker-Compose-Files/docker-compose-MAC-Linux.yml
+++ b/Docker-Compose-Files/docker-compose-MAC-Linux.yml
@@ -13,6 +13,6 @@ services:
       - PUID=0
       - PGID=0
       - COMPOSE_DIR=/compose
-    image: selfhostedpro/yacht
+    image: wickedyoda/yacht:main
 volumes:
   yacht:

--- a/Docker-Compose-Files/docker-compose-w-traefik.yml
+++ b/Docker-Compose-Files/docker-compose-w-traefik.yml
@@ -10,7 +10,7 @@ networks:
 
 services:
   yacht:
-    image: selfhostedpro/yacht:devel
+    image: wickedyoda/yacht:main
     restart: unless-stopped
     networks:
       - traefik_network

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./frontend/ ./
 RUN npm run build --verbose
 
 # Setup Container and install Flask backend
-FROM python:3.11-alpine as deploy-stage
+FROM python:3.12-alpine as deploy-stage
 
 # Set environment variables
 ENV PYTHONIOENCODING=UTF-8

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,7 +17,7 @@ fastapi==0.103.1
 fastapi-jwt-auth==0.5.0
 gunicorn==20.1.0
 h11==0.14.0
-httptools==0.5.0
+httptools==0.6.4
 idna==3.4
 python-jose==3.3.0
 makefun==1.15.0
@@ -42,7 +42,7 @@ sse-starlette==2.1.3
 typing-extensions==4.7.1
 urllib3==2.0.4
 uvicorn==0.22.0
-uvloop==0.17.0
+uvloop==0.21.0
 # websocket-client==1.7.2 (wrong version cant deploy)
 websocket-client==1.6.4
 websockets==11.0.2


### PR DESCRIPTION
## Summary
- use Python 3.12 base image
- bump `httptools` and `uvloop` for Python 3.12 support
- reference `wickedyoda/yacht` images in compose files

## Testing
- `pip install -r backend/requirements.txt`
- `npm install --prefix frontend` *(fails: registry.npm.taobao.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685707ef9e7c83239e76aa520356c5f7