### PR TITLE
Fix Docker workflow indentation

### DIFF
--- a/.github/workflows/github-docker-publish.yml
+++ b/.github/workflows/github-docker-publish.yml
@@ -1,7 +1,9 @@
-  name: Docker
+---
+# yamllint disable rule:line-length
+name: Docker
 
-on:
-  workflow_dispatch:   # enables “Run workflow” button
+'on':
+  workflow_dispatch: {}  # enables "Run workflow" button
   push:
     branches:
       - main
@@ -42,15 +44,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract Docker metadata
-          id: meta
-          uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
-          with:
-            images: ghcr.io/${{ github.repository }}
-            tags: |
-              type=ref,event=branch
-              type=semver,pattern={{version}}
-              type=raw,value=latest
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934  # v5.0.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         id: build-and-push


### PR DESCRIPTION
## Summary
- add YAML document start and disable yamllint line-length warnings
- quote `on:` section and allow manual workflow dispatch
- fix indentation for Extract Docker metadata step

## Testing
- `yamllint .github/workflows/github-docker-publish.yml`
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbe87b7d08323966d8686250a4f8a