### PR TITLE
Fix Docker build pip permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,10 @@ RUN curl -L "https://github.com/docker/compose/releases/download/v2.20.0/docker-
     chmod +x /usr/local/bin/docker-compose
 
 # Upgrade pip, setuptools, and wheel
-RUN pip3 install --upgrade pip setuptools wheel
+RUN pip3 install --upgrade pip setuptools wheel --break-system-packages
 
 # Install Python packages from requirements.txt
-RUN pip3 install -r requirements.txt --no-cache-dir --verbose
+RUN pip3 install -r requirements.txt --no-cache-dir --verbose --break-system-packages
 
 # Install SASS via gem
 RUN gem install sass --verbose


### PR DESCRIPTION
## Summary
- update Dockerfile to include `--break-system-packages` for pip

## Testing
- `python3 -m compileall -q backend/api`

------
https://chatgpt.com/codex/tasks/task_e_6861b3751e8c8323800f7f3ef65fe08e